### PR TITLE
Added ability to name imports

### DIFF
--- a/src/insertRequire.js
+++ b/src/insertRequire.js
@@ -71,7 +71,10 @@ module.exports = function(value, insertAtCursor, config) {
       })
       .then(importname => {
         if (importname === undefined) reject('Cancelled')
-        else resolve(importName)
+        else {
+          importName = importname
+          resolve()
+        }
       })
   })
     .then(() => {

--- a/src/insertRequire.js
+++ b/src/insertRequire.js
@@ -64,7 +64,17 @@ module.exports = function(value, insertAtCursor, config) {
   const lineStart = getPosition(codeBlock, isExternal)
   const cursorPosition = editor.selection.active
 
-  return Promise.resolve(detectFileRequireMethod(codeBlock))
+  return Promise.resolve(
+    vscode.window
+      .showInputBox({
+        value: importName
+      })
+      .then(importname => {
+        importName = importname
+        return importName
+      })
+  )
+    .then(detectFileRequireMethod(codeBlock))
     .then(requireMethod => {
       if (requireMethod !== null) return requireMethod
 

--- a/src/insertRequire.js
+++ b/src/insertRequire.js
@@ -64,16 +64,16 @@ module.exports = function(value, insertAtCursor, config) {
   const lineStart = getPosition(codeBlock, isExternal)
   const cursorPosition = editor.selection.active
 
-  return Promise.resolve(
+  return new Promise((resolve, reject) => {
     vscode.window
       .showInputBox({
         value: importName
       })
       .then(importname => {
-        importName = importname
-        return importName
+        if (importname === undefined) reject('Cancelled')
+        else resolve(importName)
       })
-  )
+  })
     .then(detectFileRequireMethod(codeBlock))
     .then(requireMethod => {
       if (requireMethod !== null) return requireMethod

--- a/src/insertRequire.js
+++ b/src/insertRequire.js
@@ -74,7 +74,9 @@ module.exports = function(value, insertAtCursor, config) {
         else resolve(importName)
       })
   })
-    .then(detectFileRequireMethod(codeBlock))
+    .then(() => {
+      return detectFileRequireMethod(codeBlock)
+    })
     .then(requireMethod => {
       if (requireMethod !== null) return requireMethod
 


### PR DESCRIPTION
Sometimes you need a custom name for an import, so I added an input-box after selecting a quick-pick-option, which allows you to set a custom name for the import.