### PR TITLE
Only remove js/jsx/ts extensions at end of path

### DIFF
--- a/src/insertRequire.js
+++ b/src/insertRequire.js
@@ -51,7 +51,7 @@ module.exports = function(value, insertAtCursor, config) {
       }
     }
     // get rid of file extension
-    relativePath = relativePath.replace(/\.(j|t)sx?/, '')
+    relativePath = relativePath.replace(/\.(j|t)sx?$/, '')
   } else {
     // A core module or dependency was selected
     isExternal = true


### PR DESCRIPTION
If you want to import a JSON file called `foo.json`, the extension currently inserts `fooon` because it replaces `.js` anywhere in the string. This PR adds an anchor to the end of the path to ensure this doesn't happen.