### PR TITLE
Support import variable names with subsequent uppercase characters

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,6 +138,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "prefer single quote if autodetect fails."
+                },
+                "node_require.preserveAcronymCase": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "convert filename to camelCase but preserves acronyms like `devSQLConfig` or `XMLImporter`."
                 }
             }
         },

--- a/src/caseName.js
+++ b/src/caseName.js
@@ -1,7 +1,11 @@
 const _ = require('lodash')
 
 module.exports = function(originalName) {
-  const camel = _.camelCase(originalName)
-  const fixedCase = originalName.slice(0, 1) + camel.slice(1)
-  return fixedCase
+  const caseName = _.startCase(originalName).split(' ').join('')
+
+  if (/^[a-z]/.test(originalName)) {
+    return _.lowerFirst(caseName)
+  }
+
+  return caseName
 }

--- a/src/caseName.js
+++ b/src/caseName.js
@@ -1,11 +1,17 @@
 const _ = require('lodash')
 
-module.exports = function(originalName) {
-  const caseName = _.startCase(originalName).split(' ').join('')
+module.exports = function(originalName, preserveAcronymCase) {
+  if (preserveAcronymCase) {
+    const caseName = _.startCase(originalName)
+      .split(' ')
+      .join('')
 
-  if (/^[a-z]/.test(originalName)) {
-    return _.lowerFirst(caseName)
+    if (/^[a-z]/.test(originalName)) {
+      return _.lowerFirst(caseName)
+    }
+
+    return caseName
   }
 
-  return caseName
+  return originalName.slice(0, 1) + _.camelCase(originalName).slice(1)
 }

--- a/src/insertRequire.js
+++ b/src/insertRequire.js
@@ -12,6 +12,7 @@ const getPosition = require('./getPosition')
 const isRequire = require('./isRequire')
 
 module.exports = async function(value, insertAtCursor, config) {
+  const convertCase = filename => caseName(filename, config.preserveAcronymCase)
   const editor = vscode.window.activeTextEditor
   let relativePath
   let importName
@@ -42,7 +43,7 @@ module.exports = async function(value, insertAtCursor, config) {
         )
       }
 
-      const baseName = caseName(path.basename(relativePath).split('.')[0])
+      const baseName = convertCase(path.basename(relativePath).split('.')[0])
       const aliasName = commonNames(baseName, config.aliases)
       importName = aliasName || baseName
       // selected a path in the same directory as current file
@@ -57,7 +58,7 @@ module.exports = async function(value, insertAtCursor, config) {
     isExternal = true
     relativePath = value.label
     const commonName = commonNames(value.label, config.aliases)
-    importName = commonName || caseName(value.label)
+    importName = commonName || convertCase(value.label)
   }
   const fileString = editor.document.getText()
   const codeBlock = fileString.split(os.EOL)


### PR DESCRIPTION
This pull request makes the case conversion on variable names retain the capitalisation of words.
```js
// old
import XmlImporter from './XMLImporter'

// new
import XMLImporter from './XMLImporter'
```

```js
// old
import globalIdResolver from './globalIDResolver'

// new
import globalIDResolver from './globalIDResolver'
```

This change is opinionated and I understand that this might not be the expected behaviour for some. Let me know what you think.